### PR TITLE
Scraping de ofertas do site chavesnamao.com.br

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This microservice is responsible for scraping prices from third-party websites b
 ## Project Structure
 - **`PriceScraper` Interface**: Defines the contract for scraping services. Implementations of this interface should specify how to search and extract offer data.
 - **`OlxScraperService` Implementation**: Performs scraping of offers from the OLX website based on the parameters provided in the request DTO.
+- **`ChavesNaMaoService` Implementation**: Performs scraping of offers from the Chaves Na Mão website based on the parameters provided in the request DTO.
 
 ## Requests
 The microservice exposes a single endpoint:
@@ -26,7 +27,8 @@ The microservice exposes a single endpoint:
   "brand": "Vehicle brand",
   "model": "Vehicle model",
   "year": "Vehicle year",
-  "version": "Vehicle version"
+  "version": "Vehicle version",
+  "fipeCode": "Vehicle fipe code"
 }
 ```
 - **Response**: A list of `StorePrice` objects representing the offers collected from the scraping:
@@ -37,7 +39,13 @@ The microservice exposes a single endpoint:
     "vehicleId": "UUID of the vehicle",
     "store": "Store name",
     "price": "Offer price",
+    "mileageInKm": "Vehicle mileage",
+    "year": "Vehicle year",
     "dealUrl": "Offer URL",
+    "imageUrl": "Vehicle image url",
+    "isFullMatch": "Indicates weather the deal fully matches the specified brand, model, year, version and FIPE code",
+    "city": "Offer city",
+    "state": "Offer state",
     "scrapedAt": "Date and time of scraping"
   }
 ]
@@ -55,23 +63,43 @@ The microservice exposes a single endpoint:
 curl -X POST http://localhost:8081/deals \
   -H "Content-Type: application/json" \
   -d '{
-    "vehicleId": "123e4567-e89b-12d3-a456-426614174000",
+    "vehicleId": "200976e5-eeb1-41b9-b396-3c54f0dc909c",
     "type": "CAR",
-    "brand": "Volkswagen",
-    "model": "Gol",
-    "year": "2020",
-    "version": "1.0 Flex"
+    "brand": "Fiat",
+    "model": "Doblo",
+    "year": "2004 Gasolina",
+    "version": "Doblo Adventure/ Adv.ER 1.8 mpi 8V 103cv",
+    "fipeCode": "001204-1"
   }'
 ```
 ### Example Response
 ```json
 [
   {
-    "vehicleId": "123e4567-e89b-12d3-a456-426614174000",
-    "store": "OLX",
-    "price": 35000.0,
-    "dealUrl": "https://www.olx.com.br/ad/12345",
-    "scrapedAt": "2024-10-10T14:48:23"
+    "vehicleId": "200976e5-eeb1-41b9-b396-3c54f0dc909c",
+    "store": "Chaves Na Mão",
+    "price": 64900.0,
+    "mileageInKm": null,
+    "year": "2013",
+    "dealUrl": "https://www.chavesnamao.com.br/carro/ce-fortaleza/fiat-doblo-1.8-mpi-adventure-16v-4p-2013-mecanico-RS64900/id-2449910/",
+    "imageUrl": "https://www.chavesnamao.com.br/imn/0150X0100/N/veiculos/94881/2449910/fiat-doblo-1-8-mpi-adventure-16v-4p_f20bf767e8b.jpeg",
+    "isFullMatch": false,
+    "city": "Fortaleza",
+    "state": "CE",
+    "scrapedAt": "2024-10-15T14:18:26.003611"
+  },
+  {
+    "vehicleId": "200976e5-eeb1-41b9-b396-3c54f0dc909c",
+    "store": "Olx",
+    "price": 27000.0,
+    "mileageInKm": 100000.0,
+    "year": "2004",
+    "dealUrl": "https://go.olx.com.br/grande-goiania-e-anapolis/autos-e-pecas/carros-vans-e-utilitarios/fiat-doblo-motorhome-2004-1344489072",
+    "imageUrl": "https://img.olx.com.br/images/16/166425571717502.jpg",
+    "isFullMatch": true,
+    "city": "Goiânia",
+    "state": "GO",
+    "scrapedAt": "2024-10-15T14:18:27.4745949"
   }
 ]
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
             <artifactId>jsoup</artifactId>
             <version>1.18.1</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.12.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/scraping/scrapingmicroservice/config/ScrapingConfig.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/config/ScrapingConfig.java
@@ -41,7 +41,7 @@ public class ScrapingConfig {
     @Bean
     public List<PriceScraper> scrapers() {
         List<PriceScraper> scrapers = new ArrayList<>();
-//        scrapers.add(new OlxScraperService());
+        scrapers.add(new OlxScraperService());
         scrapers.add(new ChavesNaMaoScraperService());
 
         return scrapers;

--- a/src/main/java/com/scraping/scrapingmicroservice/config/ScrapingConfig.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/config/ScrapingConfig.java
@@ -1,6 +1,7 @@
 package com.scraping.scrapingmicroservice.config;
 
 import com.scraping.scrapingmicroservice.interfaces.PriceScraper;
+import com.scraping.scrapingmicroservice.services.ChavesNaMaoScraperService;
 import com.scraping.scrapingmicroservice.services.OlxScraperService;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.chrome.ChromeDriver;
@@ -10,6 +11,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Scope;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Configuration
@@ -38,6 +40,10 @@ public class ScrapingConfig {
 
     @Bean
     public List<PriceScraper> scrapers() {
-        return List.of(new OlxScraperService());
+        List<PriceScraper> scrapers = new ArrayList<>();
+//        scrapers.add(new OlxScraperService());
+        scrapers.add(new ChavesNaMaoScraperService());
+
+        return scrapers;
     }
 }

--- a/src/main/java/com/scraping/scrapingmicroservice/dto/StorePricesRequestDTO.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/dto/StorePricesRequestDTO.java
@@ -22,7 +22,10 @@ public record StorePricesRequestDTO(
         String year,
 
         @NotNull
-        String version
+        String version,
+
+        @NotNull
+        String fipeCode
 ) {
 
 }

--- a/src/main/java/com/scraping/scrapingmicroservice/enums/ScrapedSites.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/enums/ScrapedSites.java
@@ -1,0 +1,16 @@
+package com.scraping.scrapingmicroservice.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ScrapedSites {
+    OLX("Olx"),
+    CHAVES_NA_MAO("Chaves Na Mão");
+
+    private final String name;
+
+    ScrapedSites(String description) {
+        this.name = description;
+    }
+
+}

--- a/src/main/java/com/scraping/scrapingmicroservice/models/StorePrice.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/models/StorePrice.java
@@ -8,6 +8,8 @@ public record StorePrice (
         String store,
         Double price,
         Double mileageInKm,
+        String modelName,
+        String versionName,
         String year,
         String dealUrl,
         String imageUrl,

--- a/src/main/java/com/scraping/scrapingmicroservice/models/StorePrice.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/models/StorePrice.java
@@ -8,9 +8,12 @@ public record StorePrice (
         String store,
         Double price,
         Double mileageInKm,
+        String year,
         String dealUrl,
         String imageUrl,
         Boolean fullMatch,
+        String city,
+        String state,
         LocalDateTime scrapedAt
 ){
 }

--- a/src/main/java/com/scraping/scrapingmicroservice/models/StorePrice.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/models/StorePrice.java
@@ -10,6 +10,7 @@ public record StorePrice (
         Double mileageInKm,
         String dealUrl,
         String imageUrl,
+        Boolean fullMatch,
         LocalDateTime scrapedAt
 ){
 }

--- a/src/main/java/com/scraping/scrapingmicroservice/models/StorePrice.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/models/StorePrice.java
@@ -11,7 +11,7 @@ public record StorePrice (
         String year,
         String dealUrl,
         String imageUrl,
-        Boolean fullMatch,
+        Boolean isFullMatch,
         String city,
         String state,
         LocalDateTime scrapedAt

--- a/src/main/java/com/scraping/scrapingmicroservice/services/ChavesNaMaoScraperService.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/services/ChavesNaMaoScraperService.java
@@ -6,7 +6,6 @@ import com.scraping.scrapingmicroservice.enums.VehicleType;
 import com.scraping.scrapingmicroservice.interfaces.PriceScraper;
 import com.scraping.scrapingmicroservice.models.StorePrice;
 import com.scraping.scrapingmicroservice.utils.ScrapingUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -28,6 +27,22 @@ public class ChavesNaMaoScraperService implements PriceScraper {
     @Value("${scrapingservice.baseurl.chavesnamao}")
     private String chavesNaMaoBaseUrl;
 
+    /**
+     * Scrapes prices from Chaves na Mão listings for a given vehicle type, model, and year.
+     * This service scrapes vehicle prices from the Chaves na Mão website based on the provided
+     * {@link StorePricesRequestDTO}. It navigates to a dynamically generated URL based on the vehicle
+     * details, searches for deals using XPath and CSS selectors, and extracts relevant pricing information.
+     *
+     * If the vehicle type is a truck, it returns an empty list because Chaves na Mão does not support
+     * truck listings in its FIPE section. The method includes a delay to ensure the page has fully loaded
+     * before extracting data.
+     *
+     * @param driver the WebDriver instance used to navigate the Chaves na Mão website
+     * @param request the request containing vehicle details (brand, model, year, and FIPE code)
+     * @return a list of {@link StorePrice} objects containing the scraped prices from Chaves na Mão listings,
+     *         or an empty list if no matching offers are found or if the vehicle type is a truck
+     * @throws InterruptedException if the thread is interrupted during the wait for the page to load
+     */
     @Override
     public List<StorePrice> scrapePrices(WebDriver driver, StorePricesRequestDTO request) throws InterruptedException {
         if (request.type().equals(VehicleType.TRUCK)) {

--- a/src/main/java/com/scraping/scrapingmicroservice/services/ChavesNaMaoScraperService.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/services/ChavesNaMaoScraperService.java
@@ -39,6 +39,17 @@ public class ChavesNaMaoScraperService implements PriceScraper {
             // verificar na listagem de versões o código da fipe
             WebElement vehiclelink = row.findElement(By.cssSelector("a"));
             vehiclelink.click();
+
+            List<WebElement> deals = driver.findElements(By.cssSelector("#similares span"));
+
+            deals.forEach(deal -> {
+                String baseUrl = "https://www.chavesnamao.com.br";
+                String dealUrl = deal.findElement(By.cssSelector("a")).getAttribute("href");
+                String imageUrl = deal.findElement(By.cssSelector("img")).getAttribute("src");
+                String store = "Carro Na Mão";
+                String price = deal.findElement(By.cssSelector(".price")).getText();
+                String milageInKm = deal.findElement(By.cssSelector(".milage")).getText();
+            });
         } catch (NoSuchElementException e) {
             return List.of();
         }

--- a/src/main/java/com/scraping/scrapingmicroservice/services/ChavesNaMaoScraperService.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/services/ChavesNaMaoScraperService.java
@@ -1,0 +1,58 @@
+package com.scraping.scrapingmicroservice.services;
+
+import com.scraping.scrapingmicroservice.dto.StorePricesRequestDTO;
+import com.scraping.scrapingmicroservice.enums.VehicleType;
+import com.scraping.scrapingmicroservice.interfaces.PriceScraper;
+import com.scraping.scrapingmicroservice.models.StorePrice;
+import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class ChavesNaMaoScraperService implements PriceScraper {
+    private static final Logger log = LoggerFactory.getLogger(ChavesNaMaoScraperService.class);
+    @Value("${scrapingservice.baseurl.chavesnamao}")
+    private String chavesNaMaoBaseUrl;
+
+    @Override
+    public List<StorePrice> scrapePrices(WebDriver driver, StorePricesRequestDTO request) throws InterruptedException {
+        if (request.type().equals(VehicleType.TRUCK)) {
+            return List.of();
+        }
+
+        // acessar página em que a url segue padrão marca/modelo/ano
+        String fullUrl = this.getFormattedUrl(request);
+
+        driver.get(fullUrl);
+
+        try {
+            String fipeCode = request.fipeCode();
+            WebElement row = driver.findElement(By.xpath("//td[text()='" + fipeCode + "']/parent::tr"));
+
+            // verificar na listagem de versões o código da fipe
+            WebElement vehiclelink = row.findElement(By.cssSelector("a"));
+            vehiclelink.click();
+        } catch (NoSuchElementException e) {
+            return List.of();
+        }
+
+        // se código da fipe for igual ao do veículo passado, entrar no link correspondente
+
+        // pegar as ofertas da página correspondente
+
+        return List.of();
+    }
+
+    private String getFormattedUrl(StorePricesRequestDTO request) {
+        String year = request.year().split(" ")[0];
+
+        return this.chavesNaMaoBaseUrl + "/" + request.brand() + "/" + request.model() + "/" + year;
+    }
+}

--- a/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
@@ -11,6 +11,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -18,12 +19,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-@Component
+//@Service
 public class OlxScraperService implements PriceScraper {
 
     private static final Logger log = LoggerFactory.getLogger(OlxScraperService.class);
 
-    @Value("${olx.search.baseurl}")
+    @Value("${scrapingservice.baseurl.olx}")
     private String olxBaseUrl;
 
     private final Map<String, String> olxAlternativeBrandNames = new HashMap<>() {{

--- a/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
@@ -152,7 +152,7 @@ public class OlxScraperService implements PriceScraper {
         String year = this.extractYear(deal);
         String dealUrl = this.extractDealUrl(deal);
         String imageUrl = this.extractImageUrl(deal);
-        Boolean isFullMatch = false;
+        Boolean isFullMatch = true;
         String city = this.extractCity(deal);
         String state = this.extractState(deal);
         LocalDateTime scrapedAt = LocalDateTime.now();

--- a/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
@@ -10,7 +10,6 @@ import org.openqa.selenium.WebElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
@@ -19,7 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-//@Service
+@Service
 public class OlxScraperService implements PriceScraper {
 
     private static final Logger log = LoggerFactory.getLogger(OlxScraperService.class);
@@ -79,8 +78,8 @@ public class OlxScraperService implements PriceScraper {
     private String getFormattedUrl(StorePricesRequestDTO request) {
         String type = request.type().getDescription();
         String brand = this.olxAlternativeBrandNames.getOrDefault(request.brand().toLowerCase(), request.brand());
-        String model = this.getFirstWord(request.model());
-        String year = this.getFirstWord(request.year());
+        String model = request.model().split(" ")[0];
+        String year = request.year().split(" ")[0];
         String version = request.version()
                 .replace(" ", "-")
                 .replace("/", "")
@@ -90,11 +89,7 @@ public class OlxScraperService implements PriceScraper {
         return this.olxBaseUrl + "/" + type + "/" + brand + "/" + model + "/" + year + "/" + version;
     }
 
-    private String getFirstWord(String string) {
-        return string.split(" ")[0];
-    }
-
-    private Double extractPriceFromString(String priceText) {
+    private Double convertPriceToDouble(String priceText) {
         try {
             return Double.parseDouble(priceText.split(" ")[1].replace(",", ".").replace(".", ""));
         } catch (NumberFormatException e) {
@@ -103,7 +98,7 @@ public class OlxScraperService implements PriceScraper {
         }
     }
 
-    private Double extractMileageFromString(String mileageText) {
+    private Double convertMileageToDouble(String mileageText) {
         try {
             return Double.parseDouble(mileageText.split(" ")[0].replace(",", ".").replace(".", ""));
         } catch (NumberFormatException e) {
@@ -121,10 +116,14 @@ public class OlxScraperService implements PriceScraper {
         return new StorePrice(
                 request.vehicleId(),
                 "Olx",
-                this.extractPriceFromString(priceText),
-                this.extractMileageFromString(mileageText),
+                this.convertPriceToDouble(priceText),
+                this.convertMileageToDouble(mileageText),
+                request.year(), // FIXME
                 dealUrl,
                 imageUrl,
+                false,
+                "",
+                "",
                 LocalDateTime.now()
         );
     }

--- a/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
@@ -6,6 +6,7 @@ import com.scraping.scrapingmicroservice.enums.VehicleType;
 import com.scraping.scrapingmicroservice.interfaces.PriceScraper;
 import com.scraping.scrapingmicroservice.models.StorePrice;
 import com.scraping.scrapingmicroservice.utils.ScrapingUtils;
+import org.apache.commons.text.WordUtils;
 import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
@@ -149,6 +150,8 @@ public class OlxScraperService implements PriceScraper {
         String siteName = ScrapedSites.OLX.getName();
         Double value = this.extractValue(deal);
         Double mileage = this.extractMileage(deal);
+        String modelName = WordUtils.capitalizeFully(request.brand() + " " + request.model());
+        String versionName = WordUtils.capitalizeFully(request.version());
         String year = this.extractYear(deal);
         String dealUrl = this.extractDealUrl(deal);
         String imageUrl = this.extractImageUrl(deal);
@@ -157,6 +160,18 @@ public class OlxScraperService implements PriceScraper {
         String state = this.extractState(deal);
         LocalDateTime scrapedAt = LocalDateTime.now();
 
-        return new StorePrice(vehicleId, siteName, value, mileage, year, dealUrl, imageUrl, isFullMatch, city, state, scrapedAt);
+        return new StorePrice(vehicleId,
+                              siteName,
+                              value,
+                              mileage,
+                              modelName,
+                              versionName,
+                              year,
+                              dealUrl,
+                              imageUrl,
+                              isFullMatch,
+                              city,
+                              state,
+                              scrapedAt);
     }
 }

--- a/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/services/OlxScraperService.java
@@ -94,6 +94,11 @@ public class OlxScraperService implements PriceScraper {
         return this.olxBaseUrl + "/" + type + "/" + brand + "/" + model + "/" + year + "/" + version;
     }
 
+    private Double extractValue(WebElement deal) {
+        String priceText = deal.findElement(By.className("olx-ad-card__price")).getText().trim();
+        return ScrapingUtils.convertPriceToDouble(priceText);
+    }
+
     private Double convertMileageToDouble(String mileageText) {
         try {
             return Double.parseDouble(mileageText.split(" ")[0]
@@ -105,17 +110,12 @@ public class OlxScraperService implements PriceScraper {
         }
     }
 
-    private Double extractValue(WebElement deal) {
-        String priceText = deal.findElement(By.className("olx-ad-card__price")).getText().trim();
-        return ScrapingUtils.convertPriceToDouble(priceText);
+    private String extractYear(WebElement deal) {
+        return deal.findElement(By.cssSelector("li.olx-ad-card__labels-item:first-child span")).getText();
     }
 
     private String extractDealUrl(WebElement deal) {
         return deal.findElement(By.className("olx-ad-card__link-wrapper")).getAttribute("href");
-    }
-
-    private String extractYear(WebElement deal) {
-        return deal.findElement(By.cssSelector("li.olx-ad-card__labels-item:first-child span")).getText();
     }
 
     private Double extractMileage(WebElement deal) {

--- a/src/main/java/com/scraping/scrapingmicroservice/utils/ScrapingUtils.java
+++ b/src/main/java/com/scraping/scrapingmicroservice/utils/ScrapingUtils.java
@@ -1,0 +1,18 @@
+package com.scraping.scrapingmicroservice.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ScrapingUtils {
+
+    private static final Logger log = LoggerFactory.getLogger(ScrapingUtils.class);
+
+    public static Double convertPriceToDouble(String priceText) {
+        try {
+            return Double.parseDouble(priceText.split(" ")[1].replace(",", ".").replace(".", ""));
+        } catch (NumberFormatException e) {
+            log.error("Could not parse price from string: {}", priceText);
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,4 +12,5 @@ spring.rabbitmq.addresses=amqps://jjsofydr:48SeiQGjrcF_VaJEQz_7RAhAR73sW6sl@rat.
 chromedriver.path=src/main/resources/chromedriver.exe
 chromedriver.useragent=Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:131.0) Gecko/20100101 Firefox/131.0
 
-olx.search.baseurl=https://www.olx.com.br/tabela-fipe
+scrapingservice.baseurl.olx=https://www.olx.com.br/tabela-fipe
+scrapingservice.baseurl.chavesnamao=https://www.chavesnamao.com.br/tabela-fipe


### PR DESCRIPTION
Esse PR implementa um scraper para ofertas do site chavesnamao.com.br e acrescenta alguns campos no objeto que representa o anúncio: 
- `modelName`
- `versionName`
- `year`
- `isFullMatch` : indica se a oferta corresponde ao veículo em marca, modelo, ano, versão e código FIPE. Na Olx foi possível associar diretamente, mas no chavesnamão as ofertas carregadas são com base no modelo, e carregam ofertas de outros anos e versões diferentes do veículo específico pesquisado.
- `city`
- `state`

![image](https://github.com/user-attachments/assets/8182ef0d-750a-42af-af0b-79793d9bb439)

