### PR TITLE
🔨 refactor: chmod +X to solve permission denied RUN mvnw on Unix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /app
 COPY . /app
 
 COPY ./src/main/resources/chromedriver /usr/local/bin/chromedriver
-RUN chmod +x /usr/local/bin/chromedriver
+RUN chmod +x /app/mvnw && ./mvnw clean package -DskipTests
 
 RUN ./mvnw clean package -DskipTests
 


### PR DESCRIPTION
Neste Pull request foi adicionado a permissão de excrita no Dockerfile para RUN mvnw